### PR TITLE
chore: auto-update tsnapi snapshot on nova-api dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-nova-api.yml
+++ b/.github/workflows/auto-merge-nova-api.yml
@@ -7,6 +7,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  update-api-snapshot:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      contains(github.event.pull_request.title, '@wandelbots/nova-api')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.MERGE_TOKEN }}
+      - uses: ./.github/actions/setup-node
+      # Additions to the nova-api surface are expected here, so regenerate
+      # the tsnapi snapshot instead of letting CI fail on the diff.
+      - name: Regenerate tsnapi API snapshot
+        run: pnpm run build
+        env:
+          CI: ""
+      - name: Commit snapshot if it changed
+        run: |
+          if ! git diff --quiet -- __snapshots__; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add __snapshots__
+            git commit -m "chore: update tsnapi API snapshot for nova-api bump"
+            git push origin HEAD:"${{ github.event.pull_request.head.ref }}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
   auto-merge:
     runs-on: ubuntu-latest
     if: >-

--- a/.github/workflows/auto-merge-nova-api.yml
+++ b/.github/workflows/auto-merge-nova-api.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.MERGE_TOKEN }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       # Additions to the nova-api surface are expected here, so regenerate
       # the tsnapi snapshot instead of letting CI fail on the diff.
@@ -31,6 +31,7 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add __snapshots__
             git commit -m "chore: update tsnapi API snapshot for nova-api bump"
+            gh auth setup-git
             git push origin HEAD:"${{ github.event.pull_request.head.ref }}"
           fi
         env:


### PR DESCRIPTION
Adds an `update-api-snapshot` job to the nova-api auto-merge workflow. It rebuilds the package with `CI` unset (so tsnapi auto-updates instead of failing) on dependabot @wandelbots/nova-api PRs, and pushes the regenerated `__snapshots__/tsnapi` files back to the PR branch if they changed. This unblocks CI/auto-merge for the common case of nova-api additions, without needing manual snapshot fixes (as was needed for #319).